### PR TITLE
Add missing versionomy dependency introduced in e0548808.

### DIFF
--- a/polisher.gemspec
+++ b/polisher.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |s|
   s.add_dependency('colored')
   s.add_dependency('awesome_spawn')
   s.add_dependency('gem2rpm')
+  s.add_dependency('versionomy')
   s.add_development_dependency('rspec', '>= 2.0.0')
 end


### PR DESCRIPTION
Fixes 'cannot load such file -- versionomy (LoadError)' when running rake spec.

When we get closer to version 1.0, we should try to be good with following semantic versioning and bump the minor version, for example: from 0.6.1 -> 0.7.0.
