### PR TITLE
Polisher is a module, not a class.

### DIFF
--- a/lib/polisher/version.rb
+++ b/lib/polisher/version.rb
@@ -1,3 +1,3 @@
-class Polisher
+module Polisher
   VERSION = "0.6.1"
 end


### PR DESCRIPTION
Fixes the error 'Polisher is not a module (TypeError)' when the version.rb is loaded via the gemspec before the various class files.

As an example, this occurs when you run bundle exec rake spec.
