### PR TITLE
Small follow on fix to ea3dcf8b omit :default inclusion

### DIFF
--- a/lib/polisher/gemfile.rb
+++ b/lib/polisher/gemfile.rb
@@ -50,7 +50,6 @@ module Polisher
       metadata = {}
       metadata[:deps] =
         definition.dependencies.select { |d|
-           d.groups.include?(:default)  ||                  # dep in all groups
            groups.nil? || groups.empty? ||                  # groups not specified
            groups.any? { |g| d.groups.include?(g.intern) }  # dep in any group
         }.collect { |d| d.name }


### PR DESCRIPTION
Now 'all' gemfile groups will be processed by default,
to retrieve those in the 'default', 'test', or other
groups, specify those to parse

https://github.com/ManageIQ/polisher/commit/ea3dcf8be478ec6eef10b1288c505dcfa7270b3a
