### PR TITLE
Include active_support module defining silence_warnings

### DIFF
--- a/lib/polisher/koji.rb
+++ b/lib/polisher/koji.rb
@@ -4,6 +4,7 @@
 # Copyright (C) 2013-2014 Red Hat, Inc.
 
 require 'xmlrpc/client'
+require 'active_support/core_ext/kernel/reporting'
 silence_warnings do
   XMLRPC::Config::ENABLE_NIL_PARSER = true
   XMLRPC::Config::ENABLE_NIL_CREATE = true


### PR DESCRIPTION
Currently if the user includes the polisher/koji module
by itself they will get an error as silence_warnings isn't
defined (pulled in by activesupport which is pulled in
elsewhere).

The adds the require on the direct dep to the module
