### PR TITLE
Implement Koji#build

### DIFF
--- a/lib/polisher/git/pkg.rb
+++ b/lib/polisher/git/pkg.rb
@@ -7,6 +7,7 @@ require 'polisher/error'
 require 'polisher/git/repo'
 require 'polisher/rpm/spec'
 require 'polisher/component'
+require 'polisher/koji'
 
 module Polisher
   module Git
@@ -18,8 +19,6 @@ module Polisher
 
         conf_attr :rpm_prefix,   'rubygem-'
         conf_attr :pkg_cmd,      '/usr/bin/fedpkg'
-        conf_attr :build_cmd,    '/usr/bin/koji'
-        conf_attr :build_tgt,    'rawhide'
         conf_attr :md5sum_cmd,   '/usr/bin/md5sum'
         conf_attr :dist_git_url, 'git://pkgs.fedoraproject.org/'
         conf_attr :fetch_tgt,    'master'
@@ -155,9 +154,10 @@ module Polisher
 
         # Run a scratch build
         def scratch_build
-          # TODO if build fails, raise error, else return output
-          cmd = "#{build_cmd} build --scratch #{build_tgt} #{srpm}"
-          in_repo { AwesomeSpawn.run(cmd) }
+          in_repo do
+            Koji.build :srpm    => srpm,
+                       :scratch => true
+          end
           self
         end
 

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -341,11 +341,10 @@ module Polisher
     end
 
     describe "#scratch_build" do
-      it "uses build command to build srpm" do
+      it "uses koji to build srpm" do
         pkg = described_class.new(:name => 'rails', :version => '1.0.0')
         pkg.should_receive(:in_repo).and_yield
-        expected = "/usr/bin/koji build --scratch rawhide rubygem-rails-1.0.0-1.*.src.rpm"
-        AwesomeSpawn.should_receive(:run).with(expected)
+        Koji.should_receive(:build).with(:srpm => pkg.srpm, :scratch => true)
         pkg.scratch_build
       end
     end


### PR DESCRIPTION
After long attempt to get koji krb auth working through ruby xmlrpc interface decided to cut loss and fall back to shelling out (this time in koji module, using this in the Git::Repo#scratch_build) and parsing the build url from output.

Includes specs
