### PR TITLE
Fix #83: Catch errors during analysis, set 'unknown' version

### DIFF
--- a/bin/gem_dependency_checker.rb
+++ b/bin/gem_dependency_checker.rb
@@ -174,6 +174,14 @@ def format_tgt(tgt)
   end
 end
 
+def format_unknown_tgt(tgt)
+  if @format.nil?
+    "#{tgt.to_s.red.bold}: " + "unknown".yellow
+  else
+    format_tgt("#{tgt} (unknown)")
+  end
+end
+
 def format_tgt_with_versions(tgt, versions)
   if @format.nil?
     "#{tgt.to_s.green.bold}: #{versions.join(', ').yellow} "
@@ -209,9 +217,12 @@ def print_dep(tgt, dep, versions)
     @last_dep = dep
   end
 
-  if versions.nil? || versions.empty? ||
-     versions.size == 1 && versions[0].nil?
+  if versions.blank? || (versions.size == 1 && versions.first.blank?)
     print format_tgt(tgt)
+
+  elsif versions.size == 1 && versions.first == :unknown
+    print format_unknown_tgt(tgt)
+
   else
     print format_tgt_with_versions(tgt, versions)
   end

--- a/lib/polisher/version_checker.rb
+++ b/lib/polisher/version_checker.rb
@@ -44,33 +44,57 @@ module Polisher
       end
 
       if should_check?(FEDORA_TARGET)
-        require 'polisher/fedora'
-        versions.merge! :fedora => Fedora.versions_for(name, &bl)
+        begin
+          require 'polisher/fedora'
+          versions.merge! :fedora => Fedora.versions_for(name, &bl)
+        rescue
+          versions.merge! :fedora => unknown_version(:fedora, name, &bl)
+        end
       end
 
       if should_check?(KOJI_TARGET)
-        require 'polisher/koji'
-        versions.merge! :koji => Koji.versions_for(name, &bl)
+        begin
+          require 'polisher/koji'
+          versions.merge! :koji => Koji.versions_for(name, &bl)
+        rescue
+          versions.merge! :koji => unknown_version(:koji, name, &bl)
+        end
       end
 
       if should_check?(GIT_TARGET)
-        require 'polisher/git/pkg'
-        versions.merge! :git => [Git::Pkg.version_for(name, &bl)]
+        begin
+          require 'polisher/git/pkg'
+          versions.merge! :git => [Git::Pkg.version_for(name, &bl)]
+        rescue
+          versions.merge! :git => unknown_version(:git, name, &bl)
+        end
       end
 
       if should_check?(YUM_TARGET)
-        require 'polisher/yum'
-        versions.merge! :yum => [Yum.version_for(name, &bl)]
+        begin
+          require 'polisher/yum'
+          versions.merge! :yum => [Yum.version_for(name, &bl)]
+        rescue
+          versions.merge! :yum => unknown_version(:yum, name, &bl)
+        end
       end
 
       if should_check?(BODHI_TARGET)
-        require 'polisher/bodhi'
-        versions.merge! :bodhi => Bodhi.versions_for(name, &bl)
+        begin
+          require 'polisher/bodhi'
+          versions.merge! :bodhi => Bodhi.versions_for(name, &bl)
+        rescue
+          versions.merge! :bodhi => unknown_version(:bodhi, name, &bl)
+        end
       end
 
       if should_check?(ERRATA_TARGET)
-        require 'polisher/errata'
-        versions.merge! :errata => Errata.versions_for(name, &bl)
+        begin
+          require 'polisher/errata'
+          versions.merge! :errata => Errata.versions_for(name, &bl)
+        rescue
+          versions.merge! :errata => unknown_version(:errata, name, &bl)
+        end
       end
 
       versions
@@ -82,6 +106,11 @@ module Polisher
     def self.version_for(name)
       versions = self.versions_for(name).values
       versions.inject(Hash.new(0)) { |total, i| total[i] += 1; total }.first
+    end
+
+    # Invoke block for specified target w/ an 'unknown' version
+    def self.unknown_version(tgt, name)
+      yield tgt, name, [:unknown]
     end
   end
 


### PR DESCRIPTION
Now if there are errors when running a query against a specified
polisher target, polisher will gracefully catch and set version
to 'unknown' for that target/pkg

Updates gem_dep_checker to handle this edge case, specs still
need tbd for version_checker
