### PR TITLE
Add '~> 2.0' specifier to rspec dev dependency

### DIFF
--- a/polisher.gemspec
+++ b/polisher.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('colored')
   s.add_dependency('activesupport')
-  s.add_development_dependency('rspec', '>= 2.0.0')
+  s.add_development_dependency('rspec', '~> 2.0')
   s.add_development_dependency('coveralls')
   s.add_development_dependency('json')
   s.add_development_dependency('curb')


### PR DESCRIPTION
RSpec 3 (just released) changes 'truthiness' expectations API.

Restricts rspec to 2.x until rspec 3.x support is more widespread
