### PR TITLE
Delay the pkgwat exception via Component.verify.

### DIFF
--- a/lib/polisher/bodhi.rb
+++ b/lib/polisher/bodhi.rb
@@ -5,18 +5,19 @@
 
 # XXX issue w/ retreiving packages from pkgwat causing sporadic issues:
 # https://github.com/fedora-infra/fedora-packages/issues/55
-
-# fedora pkgwat provides a frontend to bodhi
-require 'pkgwat'
+require 'polisher/component'
 
 module Polisher
-  class Bodhi
-    def self.versions_for(name, &bl)
-      versions = Pkgwat.get_updates("rubygem-#{name}", 'all', 'all').
-                   select  { |update| update['stable_version']  != 'None' }.
-                   collect { |update| update['stable_version'] }
-      bl.call(:bodhi, name, versions) unless(bl.nil?) 
-      versions
+  # fedora pkgwat provides a frontend to bodhi
+  Component.verify("Bodhi", "pkgwat") do
+    class Bodhi
+      def self.versions_for(name, &bl)
+        versions = Pkgwat.get_updates("rubygem-#{name}", 'all', 'all').
+                     select  { |update| update['stable_version']  != 'None' }.
+                     collect { |update| update['stable_version'] }
+        bl.call(:bodhi, name, versions) unless(bl.nil?)
+        versions
+      end
     end
   end
 end

--- a/lib/polisher/rhn.rb
+++ b/lib/polisher/rhn.rb
@@ -2,13 +2,14 @@
 #
 # Licensed under the MIT license
 # Copyright (C) 2013-2014 Red Hat, Inc.
-
-require 'pkgwat'
+require 'polisher/component'
 
 module Polisher
-  class RHN
-    def self.version_for(name)
-      # TODO
+  Component.verify("RHN", "pkgwat") do
+    class RHN
+      def self.version_for(name)
+        # TODO
+      end
     end
   end
 end


### PR DESCRIPTION
Tested this in combination with #101 and confirmed the LoadError is no longer raised and is instead delayed until you try to use the corresponding classes, see below:

```
$ bundle console
Resolving dependencies...
Failed to require gem2rpm.  Added runtime exception in Polisher::RPM::Requirement
Failed to require gem2rpm.  Added runtime exception in Polisher::RPM::Spec
Failed to require pkgwat.  Added runtime exception in Polisher::Bodhi
Failed to require pkgwat.  Added runtime exception in Polisher::RHN
Failed to require pkgwat.  Added runtime exception in Polisher::Fedora
irb(main):001:0> Polisher::Bodhi.new
RuntimeError: polisher is missing a dependency - cannot instantiate
```

Note, this branch is independent of #101 and can be merged independently.
