### PR TITLE
Turn off inheritance in const_defined? check

### DIFF
--- a/lib/polisher/component.rb
+++ b/lib/polisher/component.rb
@@ -34,7 +34,7 @@ module Polisher
       desired_namespace = Polisher
 
       klasses.each do |k|
-        desired_namespace.const_set(k, Missing) unless desired_namespace.const_defined?(k)
+        desired_namespace.const_set(k, Missing) unless desired_namespace.const_defined?(k, false)
         desired_namespace = "#{desired_namespace.name}::#{k}".constantize
       end
       warn "Failed to require #{dependency}.  Added runtime exception in Polisher::#{polisher_klass}"


### PR DESCRIPTION
This will avoid getting uninitialized constant error for Polisher::Gem
later on since Gem can be defined but Polisher::Gem not:

```
> require 'polisher'
NameError: uninitialized constant Polisher::Gem
    from /home/strzibny/.gem/ruby/gems/activesupport-4.1.4/lib/active_support/inflector/methods.rb:253:in `const_get'
    from /home/strzibny/.gem/ruby/gems/activesupport-4.1.4/lib/active_support/inflector/methods.rb:253:in `block in constantize'
    from /home/strzibny/.gem/ruby/gems/activesupport-4.1.4/lib/active_support/inflector/methods.rb:236:in `each'
    from /home/strzibny/.gem/ruby/gems/activesupport-4.1.4/lib/active_support/inflector/methods.rb:236:in `inject'
    from /home/strzibny/.gem/ruby/gems/activesupport-4.1.4/lib/active_support/inflector/methods.rb:236:in `constantize'
    from /home/strzibny/.gem/ruby/gems/activesupport-4.1.4/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:38:in `block in require_dependency'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:36:in `each'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:36:in `rescue in require_dependency'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:30:in `require_dependency'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:23:in `block in verify'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:22:in `each'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:22:in `all?'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/component.rb:22:in `verify'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/gem.rb:16:in `<module:Polisher>'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/gem.rb:13:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/rpm/requirement.rb:6:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher.rb:8:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:135:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:144:in `require'
    from (irb):1
```
