### PR TITLE
Use Component#verify only for classes

### DIFF
--- a/lib/polisher/rpm/requirement.rb
+++ b/lib/polisher/rpm/requirement.rb
@@ -8,9 +8,9 @@ require 'polisher/core'
 require 'polisher/component'
 
 module Polisher
-  deps = ['gem2rpm', 'versionomy', 'active_support/core_ext']
-  Component.verify("RPM::Requirement", *deps) do
-    module RPM
+  module RPM
+    deps = ['gem2rpm', 'versionomy', 'active_support/core_ext']
+    Component.verify("RPM::Requirement", *deps) do
       class Requirement
         include ConfHelpers
 
@@ -192,6 +192,6 @@ module Polisher
           !!(self.str =~ RPM::Spec::SPEC_GEM_REQ_MATCHER) ? $1 : nil
         end
       end # class Requirement
-    end # module RPM
-  end # Component.verify("RPM::Requirement")
+    end # Component.verify("RPM::Requirement")
+  end # module RPM
 end # module Polisher

--- a/lib/polisher/rpm/spec.rb
+++ b/lib/polisher/rpm/spec.rb
@@ -15,9 +15,9 @@ require 'polisher/rpm/compares_spec'
 require 'polisher/component'
 
 module Polisher
-  deps = ['gem2rpm', 'versionomy', 'active_support', 'active_support/core_ext']
-  Component.verify("RPM::Spec", *deps) do
-    module RPM
+  module RPM
+    deps = ['gem2rpm', 'versionomy', 'active_support', 'active_support/core_ext']
+    Component.verify("RPM::Spec", *deps) do
       class Spec
         include HasGem
         include HasRequirements
@@ -105,6 +105,6 @@ module Polisher
           @metadata[:contents]
         end
       end # class Spec
-    end # module RPM
-  end # Component.verify("RPM::Spec")
+    end # Component.verify("RPM::Spec")
+  end # module RPM
 end # module Polisher


### PR DESCRIPTION
This fixes `TypeError: RPM is not a module` when some of the dependencies are not met:

```
> require 'polisher'
TypeError: RPM is not a module
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/rpm/has_requirements.rb:10:in `<module:Polisher>'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/rpm/has_requirements.rb:9:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher/rpm/spec.rb:9:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /home/strzibny/.gem/ruby/gems/polisher-0.10.2/lib/polisher.rb:9:in `<top (required)>'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:73:in `require'
    from (irb):3
    from /usr/bin/irb:12:in `<main>'
```

After the fix:

```
> require 'polisher'
Failed to require versionomy.  Added runtime exception in Polisher::RPM::Requirement
Failed to require versionomy.  Added runtime exception in Polisher::RPM::Spec
Failed to require pkgwat.  Added runtime exception in Polisher::Bodhi
Failed to require pkgwat.  Added runtime exception in Polisher::RHN
Failed to require pkgwat.  Added runtime exception in Polisher::Fedora
=> true
```
