### PR TITLE
Fix getting latest upstream

### DIFF
--- a/lib/polisher/gem.rb
+++ b/lib/polisher/gem.rb
@@ -126,7 +126,7 @@ module Polisher
 
       # Retieve latest version of gem available on rubygems
       def self.latest_version_of(name)
-        remote_versions_for(name).first
+        remote_versions_for(name).max
       end
 
       # Return new instance of Gem from Gemspec


### PR DESCRIPTION
Polisher gets the latest upstream version by calling JSON API, collecting all the versions and than asking for the first one. But the array is NOT sorted. Thereof makes sense to ask for the highest one. This PR should solve the issue.
