### PR TITLE
Compare Gem::Version objects to be sure of the highest version

### DIFF
--- a/lib/polisher/gem.rb
+++ b/lib/polisher/gem.rb
@@ -12,7 +12,8 @@ require 'polisher/gem_state'
 
 module Polisher
   deps = ['curb', 'json', 'yaml', 'tempfile', 'pathname', 'fileutils',
-          'awesome_spawn', 'rubygems/installer', 'active_support', 'active_support/core_ext']
+          'awesome_spawn', 'rubygems/installer', 'rubygems/version',
+          'active_support', 'active_support/core_ext']
   Component.verify("Gem", *deps) do
     class Gem
       include ConfHelpers
@@ -136,7 +137,7 @@ module Polisher
 
       # Retieve latest version of gem available on rubygems
       def self.latest_version_of(name)
-        remote_versions_for(name).max
+        remote_versions_for(name).map{ |v| ::Gem::Version.new v }.max.to_s
       end
 
       # Return new instance of Gem from Gemspec

--- a/spec/gem_spec.rb
+++ b/spec/gem_spec.rb
@@ -159,8 +159,8 @@ module Polisher
       it "retrieves latests version of gem available on rubygems.org" do
         described_class.should_receive(:remote_versions_for)
                        .with('polisher')
-                       .and_return([2.2, 1.1])
-        described_class.latest_version_of('polisher').should == 2.2
+                       .and_return(['2.2', '1.1'])
+        described_class.latest_version_of('polisher').should == '2.2'
       end
     end
 


### PR DESCRIPTION
My fix for the upstream highest version doesn't work everytime as we have to compare objects of Gem::Version to be sure. This PR makes it right.

This fixes #ec9a7e5
