### PR TITLE
State all soft dependencies after install

### DIFF
--- a/polisher.gemspec
+++ b/polisher.gemspec
@@ -42,6 +42,26 @@ Gem::Specification.new do |s|
   s.add_development_dependency('vcr')
   s.add_development_dependency('webmock')
 
-  # Comes from rpmdevtools
-  s.requirements << 'rpmdev-packager'
+  s.requirements << 'json (RubyGem)'
+  s.requirements << 'curb (RubyGem)'
+  s.requirements << 'i18n (RubyGem)'
+  s.requirements << 'pkgwat (RubyGem)'
+  s.requirements << 'awesome_spawn (RubyGem)'
+  s.requirements << 'gem2rpm (RubyGem)'
+  s.requirements << 'versionomy (RubyGem)'
+  s.requirements << 'vcr (RubyGem)'
+  s.requirements << 'webmock (RubyGem)'
+  s.requirements << 'git'
+  s.requirements << 'diff'
+  s.requirements << 'fedpkg'
+  s.requirements << 'md5sum'
+  s.requirements << 'koji'
+  s.requirements << 'yum'
+  s.requirements << 'rpmdev-packager (from rpmdevtools)'
+
+  s.post_install_message = "=====================================================\n" +
+                           "Some of the Polisher components require the following\n" +
+                           "RubyGems and programs to be installed:\n\n" +
+                           s.requirements.join("\n") + "\n" +
+                           "======================================================"
 end


### PR DESCRIPTION
I finally had a time to add all of the other soft requirements. I think it makes sense to print them after installation:

```
$ gem install polisher-0.10.2.gem
=====================================================
Some of the Polisher components require the following
RubyGems and programs to be installed:

json (RubyGem)
curb (RubyGem)
i18n (RubyGem)
pkgwat (RubyGem)
awesome_spawn (RubyGem)
gem2rpm (RubyGem)
versionomy (RubyGem)
vcr (RubyGem)
webmock (RubyGem)
git
diff
fedpkg
md5sum
koji
yum
rpmdev-packager (from rpmdevtools)
=====================================================

```
