### PR TITLE
Implement VersionChecker#versions_for and #version_of methods

### DIFF
--- a/lib/polisher/version_checker.rb
+++ b/lib/polisher/version_checker.rb
@@ -130,12 +130,19 @@ module Polisher
       versions
     end
 
-    # Return version of package most frequent in all configured targets.
-    # Invokes query as normal then counts versions over all targets and
-    # returns the max.
+    # Return version of package most frequent references in each
+    # configured target.
     def self.version_for(name)
-      versions = versions_for(name).values
-      versions.inject(Hash.new(0)) { |total, i| total[i] += 1; total }.first
+      Hash[versions_for(name).collect do |k, versions|
+        most = versions.group_by { |v| v }.values.max_by(&:size).first
+        [k, most]
+      end]
+    end
+
+    # Return version of package most frequent reference in all
+    # configured targets.
+    def self.version_of(name)
+      version_for(name).values.group_by { |v| v }.values.max_by(&:size).first
     end
 
     # Invoke block for specified target w/ an 'unknown' version

--- a/spec/version_checker_spec.rb
+++ b/spec/version_checker_spec.rb
@@ -85,8 +85,28 @@ module Polisher
       it "returns all versions retrieved"
     end
 
-    describe "version for" do
-      it "retrieves most relevant version of package in configured targets"
+    describe "#version_for" do
+      it "retrieves most relevant version of package in configured targets" do
+        versions = {:koji => ['1.0', '1.0', '2.0'],
+                    :git  => ['1.0', '2.1', '2.1'],
+                    :yum  => ['0.9', '0.9', '0.9']}
+        described_class.should_receive(:versions_for).and_return(versions)
+
+        expected = {:koji => '1.0',
+                    :git  => '2.1',
+                    :yum  => '0.9'}
+        described_class.version_for('rails').should == expected
+      end
+    end
+
+    describe "#version_of" do
+      it "retrieves most relevant version of package in all targets" do
+        versions = {:koji   => '2.2',
+                    :bodhi  => '1.1',
+                    :errata => '1.1'}
+        described_class.should_receive(:version_for).and_return(versions)
+        described_class.version_of('rails').should == '1.1'
+      end
     end
   end # describe VersionChecker
 end # module Polisher


### PR DESCRIPTION
Summary: As a packager, I would like a high-level / single-value
snapshot of package versions in multiple targets & subtargets

Background: Polisher can query multiple targets (git, koji, yum, other)
as well as subtargets (git branches, koji tags, yum repos, etc)
in a single call returning metadata such as package versions for each.

Inorder to facilitate metadata abstraction (which by nature is lossy
but compact) we introduce a few methods that select the versions
most frequent found in the polisher query targets and subtargets

Implementation: Adds to methods to VersionChecker:
- versions_for: returns the most frequently referenced version in
              each configured polisher target (across all subtargets)
- versions_of:  returns the most frequently referenced version across
              all configured polisher targets

Includes specs for updated / new features.
