### PR TITLE
Genericize Version Checker Modules

### DIFF
--- a/lib/polisher/adaptors/checker_loader.rb
+++ b/lib/polisher/adaptors/checker_loader.rb
@@ -1,0 +1,78 @@
+# Version Checker Target Loader Mixin
+#
+# Licensed under the MIT license
+# Copyright (C) 2013-2014 Red Hat, Inc.
+
+require 'active_support'
+require 'active_support/core_ext'
+
+module Polisher
+  module CheckerLoader
+    # Dir which target checkers reside
+    def target_dir
+      @target_dir ||= File.expand_path(File.join(File.dirname(__FILE__), '/version_checker'))
+    end
+
+    # Targets to check
+    def targets
+      @targets ||= Dir.glob(File.join(target_dir, '*.rb'))
+                      .collect { |t| t.gsub("#{target_dir}/", '').gsub('.rb', '').intern }
+    end
+
+    # Mixin module corresponding to target
+    def target_module(target)
+      "Polisher::#{target.to_s.camelcase}VersionChecker".constantize
+    end
+
+    # Target corresponding to mixin module
+    def module_target(mod)
+      mod.to_s.gsub('Polisher::', '').gsub('VersionChecker', '').underscore.intern
+    end
+
+    # Mixed in method to check target
+    def target_method(target)
+      "#{target}_versions"
+    end
+
+    # Load specified target
+    def load_target(target)
+      raise ArgumentError, target unless targets.include?(target)
+
+      require "polisher/adaptors/version_checker/#{target}"
+
+      tm = target_module(target)
+      @target_modules ||= []
+      @target_modules << tm
+      include tm
+    end
+
+    # Load all targets
+    def load_targets
+      targets.each { |t| load_target t }
+      targets
+    end
+    alias :all_targets :load_targets
+
+    # Return modules marked as default
+    def default_modules
+      @target_modules.select { |tm| tm.default? }
+    end
+
+    # Return targets marked as default
+    def default_targets
+      default_modules.collect { |m| module_target(m) }
+    end
+
+    # Enable the specified target(s) in the list of target to check
+    def check(*target)
+      @check_list ||= []
+      target.flatten.each { |t| @check_list << t }
+    end
+
+    # Return bool indicating if target should be checked
+    def should_check?(target)
+      @check_list ||= default_targets
+      @check_list.include?(target)
+    end
+  end # module CheckerLoader
+end

--- a/lib/polisher/adaptors/version_checker.rb
+++ b/lib/polisher/adaptors/version_checker.rb
@@ -4,39 +4,12 @@
 # Copyright (C) 2013-2014 Red Hat, Inc.
 
 require 'polisher/util/logger'
-
-require 'polisher/adaptors/version_checker/gem'
-require 'polisher/adaptors/version_checker/fedora'
-require 'polisher/adaptors/version_checker/koji'
-require 'polisher/adaptors/version_checker/git'
-require 'polisher/adaptors/version_checker/yum'
-require 'polisher/adaptors/version_checker/bodhi'
-require 'polisher/adaptors/version_checker/errata'
+require 'polisher/adaptors/checker_loader'
 
 module Polisher
   class VersionChecker
     extend Logging
-
-    include GemVersionChecker
-    include FedoraVersionChecker
-    include KojiVersionChecker
-    include GitVersionChecker
-    include YumVersionChecker
-    include BodhiVersionChecker
-    include ErrataVersionChecker # not enabled by default
-
-    ALL_TARGETS   = [GEM_TARGET, KOJI_TARGET, FEDORA_TARGET, GIT_TARGET, YUM_TARGET]
-
-    # Enable the specified target(s) in the list of target to check
-    def self.check(*target)
-      @check_list ||= []
-      target.flatten.each { |t| @check_list << t }
-    end
-
-    def self.should_check?(target)
-      @check_list ||= ALL_TARGETS
-      @check_list.include?(target)
-    end
+    extend CheckerLoader
 
     # Retrieve all the versions of the specified package using
     # the configured targets.
@@ -49,13 +22,12 @@ module Polisher
     def self.versions_for(name, &bl)
       versions = {}
 
-      versions.merge! :gem    => gem_versions(name, &bl)    if should_check?(GEM_TARGET)
-      versions.merge! :fedora => fedora_versions(name, &bl) if should_check?(FEDORA_TARGET)
-      versions.merge! :koji   => koji_versions(name, &bl)   if should_check?(KOJI_TARGET)
-      versions.merge! :git    => git_versions(name, &bl)    if should_check?(GIT_VERSIONS)
-      versions.merge! :yum    => yum_versions(name, &bl)    if should_check?(YUM_VERSIONS)
-      versions.merge! :bodhi  => bodhi_versions(name, &bl)  if should_check?(BODHI_VERSIONS)
-      versions.merge! :errata => errata_versions(name, &bl) if should_check?(ERRATA_VERSIONS)
+      all_targets.each do |target|
+        if should_check?(target)
+          target_versions = send target_method(target), name, &bl
+          versions.merge! target => target_versions
+        end
+      end
 
       versions
     end

--- a/lib/polisher/adaptors/version_checker/bodhi.rb
+++ b/lib/polisher/adaptors/version_checker/bodhi.rb
@@ -5,7 +5,9 @@
 
 module Polisher
   module BodhiVersionChecker
-    BODHI_TARGET  = :bodhi  # fedora dispatches to bodhi so not enabled by default
+    def self.default?
+      @default ||= false
+    end
 
     def self.included(base)
       base.extend(ClassMethods)

--- a/lib/polisher/adaptors/version_checker/errata.rb
+++ b/lib/polisher/adaptors/version_checker/errata.rb
@@ -5,7 +5,9 @@
 
 module Polisher
   module ErrataVersionChecker
-    ERRATA_TARGET = :errata
+    def self.default?
+      @default ||= false
+    end
 
     def self.included(base)
       base.extend(ClassMethods)

--- a/lib/polisher/adaptors/version_checker/fedora.rb
+++ b/lib/polisher/adaptors/version_checker/fedora.rb
@@ -5,7 +5,9 @@
 
 module Polisher
   module FedoraVersionChecker
-    FEDORA_TARGET = :fedora
+    def self.default?
+      @default ||= true
+    end
 
     def self.included(base)
       base.extend(ClassMethods)

--- a/lib/polisher/adaptors/version_checker/gem.rb
+++ b/lib/polisher/adaptors/version_checker/gem.rb
@@ -7,7 +7,9 @@ require 'polisher/gem'
 
 module Polisher
   module GemVersionChecker
-    GEM_TARGET    = :gem
+    def self.default?
+      @default ||= true
+    end
 
     def self.included(base)
       base.extend(ClassMethods)

--- a/lib/polisher/adaptors/version_checker/git.rb
+++ b/lib/polisher/adaptors/version_checker/git.rb
@@ -5,7 +5,9 @@
 
 module Polisher
   module GitVersionChecker
-    GIT_TARGET    = :git
+    def self.default?
+      @default ||= true
+    end
 
     def self.included(base)
       base.extend(ClassMethods)

--- a/lib/polisher/adaptors/version_checker/koji.rb
+++ b/lib/polisher/adaptors/version_checker/koji.rb
@@ -5,7 +5,9 @@
 
 module Polisher
   module KojiVersionChecker
-    KOJI_TARGET   = :koji
+    def self.default?
+      @default ||= true
+    end
 
     def self.included(base)
       base.extend(ClassMethods)

--- a/lib/polisher/adaptors/version_checker/yum.rb
+++ b/lib/polisher/adaptors/version_checker/yum.rb
@@ -5,7 +5,9 @@
 
 module Polisher
   module YumVersionChecker
-    YUM_TARGET    = :yum
+    def self.default?
+      @default ||= true
+    end
 
     def self.included(base)
       base.extend(ClassMethods)


### PR DESCRIPTION
Based on #125, this genericizes version checker modules such that they are automatically loaded from the polisher/adaptors/version_checker dir
