### PR TITLE
Skip gem deps args

### DIFF
--- a/lib/polisher/cli/all.rb
+++ b/lib/polisher/cli/all.rb
@@ -12,6 +12,7 @@ require 'polisher/cli/specifier'
 require 'polisher/cli/format'
 require 'polisher/cli/conf'
 require 'polisher/cli/status'
+require 'polisher/cli/deps'
 
 module Polisher
   module CLI

--- a/lib/polisher/cli/bin/git_gem_updater.rb
+++ b/lib/polisher/cli/bin/git_gem_updater.rb
@@ -100,8 +100,12 @@ module Polisher
       end
     end
 
+    def update_args
+      skip_gem_deps_args
+    end
+
     def update_git
-      distgit_pkg.update_to(upstream_gem)
+      distgit_pkg.update_to(upstream_gem, update_args)
       # TODO append gem dependencies to conf[:gems] list
     end
 

--- a/lib/polisher/cli/bin/ruby_rpm_spec_updater.rb
+++ b/lib/polisher/cli/bin/ruby_rpm_spec_updater.rb
@@ -20,6 +20,7 @@ module Polisher
     def ruby_rpm_spec_updater_option_parser
       OptionParser.new do |opts|
         default_options               opts
+        gem_deps_options              opts
         ruby_rpm_spec_updater_options opts
       end
     end
@@ -38,6 +39,10 @@ module Polisher
       conf[:in_place]
     end
 
+    def update_args
+      skip_gem_deps_args
+    end
+
     def update_in_place
       File.write(conf[:spec_file], rpmspec.to_string)
     end
@@ -47,7 +52,7 @@ module Polisher
     end
 
     def run_update!
-      rpmspec.update_to(source)
+      rpmspec.update_to(source, update_args)
       in_place? ? update_in_place : update_to_stdout
     end
   end # module CLI

--- a/lib/polisher/cli/deps.rb
+++ b/lib/polisher/cli/deps.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/ruby
+# Polisher CLI Deps Specifier Options
+#
+# Licensed under the MIT license
+# Copyright (C) 2015 Red Hat, Inc.
+###########################################################
+
+module Polisher
+  module CLI
+    def skip_gem_deps?
+      conf[:skip_gem_deps]
+    end
+
+    def skip_gem_deps_args
+      {:skip_gem_deps => skip_gem_deps?}
+    end
+
+    def gem_deps_options(option_parser)
+      option_parser.on('--skip-gem-deps', 'Skip gem dependencies') do
+        conf[:skip_gem_deps] = true
+      end
+    end
+  end # module CLI
+end # module Polisher

--- a/lib/polisher/git/pkg/updater.rb
+++ b/lib/polisher/git/pkg/updater.rb
@@ -11,9 +11,9 @@ module Polisher
       end
 
       # Update the local spec to the specified gem version
-      def update_spec_to(gem)
+      def update_spec_to(gem, update_args)
         in_repo do
-          spec.update_to(gem)
+          spec.update_to(gem, update_args)
           File.write(spec_file, spec.to_string)
           @dirty_spec = true
         end
@@ -41,9 +41,9 @@ module Polisher
       # Update the local pkg to specified gem
       #
       # @param [Polisher::Gem] gem instance of gem containing metadata to update to
-      def update_to(gem)
+      def update_to(gem, update_args={})
         update_metadata gem
-        update_spec_to gem
+        update_spec_to gem, update_args
         gen_sources_for gem
         ignore gem
         self


### PR DESCRIPTION
Gem based Requirements are autogenerated in recent versions of RPM / Fedora so are no longer necessary.